### PR TITLE
Adapt synapse.rules to fit synapses metrics again

### DIFF
--- a/synapse.html
+++ b/synapse.html
@@ -4,12 +4,12 @@
 <h1>System Resources</h1>
 
 <h3>CPU</h3>
-<div id="process_resource_utime"></div>
+<div id="process_cpu_user_seconds_total"></div>
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#process_cpu_user_seconds_total"),
-  expr: "rate(process_cpu_user_seconds_total[2m]) / 1000",
-  name: "useconds",
+  expr: "rate(process_cpu_user_seconds_total[2m])",
+  name: "utime",
   max: 1,
   min: 0,
   renderer: "area",
@@ -22,11 +22,11 @@ new PromConsole.Graph({
 </script>
 
 <h3>Memory</h3>
-<div id="process_resource_maxrss"></div>
+<div id="process_psutil_rss_max"></div>
 <script>
 new PromConsole.Graph({
-  node: document.querySelector("#process_resource_maxrss"),
-  expr: "process_resource_maxrss",
+  node: document.querySelector("#process_psutil_rss_max"),
+  expr: "process_psutil_rss:max",
   name: "maxrss",
   min: 0,
   renderer: "line",
@@ -43,7 +43,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#process_fds"),
-  expr: "process_fds:total",
+  expr: "process_open_fds{instance=\"localhost:9091\",job=\"synapse\"}",
   name: "FDs",
   min: 0,
   renderer: "line",
@@ -62,7 +62,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#reactor_total_time"),
-  expr: "rate(reactor_tick_time:total[2m]) / 1000",
+  expr: "rate(python_twisted_reactor_tick_time:total[2m]) / 1000",
   name: "time",
   max: 1,
   min: 0,
@@ -80,7 +80,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#reactor_average_time"),
-  expr: "rate(reactor_tick_time:total[2m]) / rate(reactor_tick_time:count[2m]) / 1000",
+  expr: "rate(python_twisted_reactor_tick_time:total[2m]) / rate(python_twisted_reactor_tick_time:count[2m]) / 1000",
   name: "time",
   min: 0,
   renderer: "line",
@@ -97,7 +97,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#reactor_pending_calls"),
-  expr: "rate(reactor_pending_calls:total[30s])/rate(reactor_pending_calls:count[30s])",
+  expr: "rate(python_twisted_reactor_pending_calls:total[30s])/rate(python_twisted_reactor_pending_calls:count[30s])",
   name: "calls",
   min: 0,
   renderer: "line",
@@ -306,7 +306,7 @@ new PromConsole.Graph({
 <script>
 new PromConsole.Graph({
   node: document.querySelector("#synapse_http_server_send_time_avg"),
-  expr: "rate(synapse_http_server_response_time:total{servlet='RoomSendEventRestServlet'}[2m]) / rate(synapse_http_server_response_time:count{servlet='RoomSendEventRestServlet'}[2m]) / 1000",
+  expr: "rate(synapse_http_server_response_time:total{servlet='RoomSendEventRestServlet'}[20m]) / rate(synapse_http_server_response_time:count{servlet='RoomSendEventRestServlet'}[20m]) / 1000",
   name: "[[servlet]]",
   yAxisFormatter: PromConsole.NumberFormatter.humanize,
   yHoverFormatter: PromConsole.NumberFormatter.humanize,

--- a/synapse.html
+++ b/synapse.html
@@ -7,9 +7,9 @@
 <div id="process_resource_utime"></div>
 <script>
 new PromConsole.Graph({
-  node: document.querySelector("#process_resource_utime"),
-  expr: "rate(process_resource_utime[2m]) / 1000",
-  name: "utime",
+  node: document.querySelector("#process_cpu_user_seconds_total"),
+  expr: "rate(process_cpu_user_seconds_total[2m]) / 1000",
+  name: "useconds",
   max: 1,
   min: 0,
   renderer: "area",

--- a/synapse.rules
+++ b/synapse.rules
@@ -1,5 +1,5 @@
-synapse_federation_transaction_queue_pendingEdus:total = sum(synapse_federation_transaction_queue_pendingEdus or absent(synapse_federation_transaction_queue_pendingEdus)*0)
-synapse_federation_transaction_queue_pendingPdus:total = sum(synapse_federation_transaction_queue_pendingPdus or absent(synapse_federation_transaction_queue_pendingPdus)*0)
+synapse_federation_transaction_queue_pending_edus:total = sum(synapse_federation_transaction_queue_pending_edus or absent(synapse_federation_transaction_queue_pending_edus)*0)
+synapse_federation_transaction_queue_pending_pdus:total = sum(synapse_federation_transaction_queue_pending_pdus or absent(synapse_federation_transaction_queue_pending_pdus)*0)
 
 synapse_http_server_requests:method{servlet=""} = sum(synapse_http_server_requests) by (method)
 synapse_http_server_requests:servlet{method=""} = sum(synapse_http_server_requests) by (servlet)
@@ -15,7 +15,6 @@ synapse_federation_client_sent{type="Query"} = sum(synapse_federation_client_sen
 
 synapse_federation_server_received{type="EDU"} = synapse_federation_server_received_edus + 0
 synapse_federation_server_received{type="PDU"} = synapse_federation_server_received_pdus + 0
-synapse_federation_server_received{type="Query"} = sum(synapse_federation_server_received_queries) by (job)
 
 synapse_federation_transaction_queue_pending{type="EDU"} = synapse_federation_transaction_queue_pending_edus + 0
 synapse_federation_transaction_queue_pending{type="PDU"} = synapse_federation_transaction_queue_pending_pdus + 0


### PR DESCRIPTION
I played a bit with prometheus and used this files to get some metrics. 

Now it seems that the naming of the metrics synapse exposes have been changed. So here's ma PR to bringthe names uptodate